### PR TITLE
Use generated regexes

### DIFF
--- a/src/FlatValidator/FlatValidatorFuncs.Password.cs
+++ b/src/FlatValidator/FlatValidatorFuncs.Password.cs
@@ -78,6 +78,12 @@ public static partial class FlatValidatorFuncs
     public static PasswordStrength GetPasswordStrength(string? password) => 
         GetPasswordStrength(password, out _, out _);
 
+    [GeneratedRegex(@"(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])(19\d{2}|202\d{1})|(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])(19\d{2}|202\d{1})|(19\d{2}|202\d{1})(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])")]
+    private static partial Regex LongDateRegex();
+
+    [GeneratedRegex(@"(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])\d{2}|(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])\d{2}|\d{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])")]
+    private static partial Regex ShortDateRegex();
+
     /// <summary>
     /// Calculate the cardinality of the minimal character sets necessary to brute force the password (roughly).
     /// </summary>
@@ -198,13 +204,11 @@ public static partial class FlatValidatorFuncs
         score -= repeatableCount;
 
         // DDMMYYYY, MMDDYYYY, YYYYMMDD - long date-related patterns in the password
-        const string longDatePattern = @"(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])(19\d{2}|202\d{1})|(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])(19\d{2}|202\d{1})|(19\d{2}|202\d{1})(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])";
-        var longDatePatternScore = 5 * Regex.Count(password, longDatePattern, RegexOptions.Compiled);
+        var longDatePatternScore = 5 * LongDateRegex().Count(password);
         if (longDatePatternScore == 0)
         {
             // DDMMYY, MMDDYY, YYMMDD - short date-related patterns in the password
-            const string shortDatePattern = @"(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])\d{2}|(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])\d{2}|\d{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])";
-            longDatePatternScore = 5 * Regex.Count(password, shortDatePattern, RegexOptions.Compiled);
+            longDatePatternScore = 5 * ShortDateRegex().Count(password);
         }
         score -= longDatePatternScore;
 

--- a/src/FlatValidator/FlatValidatorFuncs.cs
+++ b/src/FlatValidator/FlatValidatorFuncs.cs
@@ -40,24 +40,27 @@ public static partial class FlatValidatorFuncs
     #endregion
 
     #region Email 
-    private const string _emailPattern = @"^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-||_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+([a-z]+|\d|-|\.{0,1}|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])?([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$";
-    private static Regex? _IsEmailRegex = null;
+    [GeneratedRegex(@"^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-||_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+([a-z]+|\d|-|\.{0,1}|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])?([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$")]
+    private static partial Regex EmailRegex();
+
     public static bool IsEmail(this string? email) =>
-        IsEmpty(email) ? false : (_IsEmailRegex ??= new Regex(_emailPattern, RegexOptions.Compiled)).IsMatch(email!);
+        !IsEmpty(email) && EmailRegex().IsMatch(email!);
     #endregion
 
     #region PhoneNumber 
-    private const string _phoneNumberPattern = @"^\+?[0-9]{1,3}[-\s]?(\(?[0-9]{2,3}\)|[0-9]{2,3})\s?([0-9]{1,3}\-?[0-9]{2,3}\-?[0-9]{2,3}|[0-9]{1,3}\s?[0-9]{2,3}\s?[0-9]{2,3})$"; // @"^([\+]?[0-9]?[0-9][0-9][-]?|[0])?[1-9][0-9]{8}$";
-    private static Regex? _phoneNumberRegex = null;
+    [GeneratedRegex(@"^\+?[0-9]{1,3}[-\s]?(\(?[0-9]{2,3}\)|[0-9]{2,3})\s?([0-9]{1,3}\-?[0-9]{2,3}\-?[0-9]{2,3}|[0-9]{1,3}\s?[0-9]{2,3}\s?[0-9]{2,3})$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
+    private static partial Regex PhoneNumberRegex();
+
     public static bool IsPhoneNumber(this string? phoneNumber) =>
-        IsEmpty(phoneNumber) ? false : (_phoneNumberRegex ??= new Regex(_phoneNumberPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)).IsMatch(phoneNumber!);
+        !IsEmpty(phoneNumber) && PhoneNumberRegex().IsMatch(phoneNumber!);
     #endregion
 
     #region CreditCardNumber
-    private const string _creditCardNumberPattern = @"^(1298|1267|4512|4567|8901|8933)([\-\s]?[0-9]{4}){3}$";
-    private static Regex? _creditCardNumberRegex = null;
+    [GeneratedRegex(@"^(1298|1267|4512|4567|8901|8933)([\-\s]?[0-9]{4}){3}$")]
+    private static partial Regex CreditCardNumberRegex();
+
     public static bool IsCreditCardNumber(this string? creditCardNumber) =>
-        string.IsNullOrWhiteSpace(creditCardNumber) ? false : (_creditCardNumberRegex ??= new Regex(_creditCardNumberPattern, RegexOptions.Compiled)).IsMatch(creditCardNumber);
+        !string.IsNullOrWhiteSpace(creditCardNumber) && CreditCardNumberRegex().IsMatch(creditCardNumber);
     #endregion
 
     #region CreditCardExpiryDate
@@ -76,40 +79,49 @@ public static partial class FlatValidatorFuncs
     #endregion
 
     #region CreditCardCVV
-    private const string _creditCardCVVPattern = @"^\d{3}$";
-    private static Regex? _creditCardCVVRegex = null;
+    [GeneratedRegex(@"^\d{3}$")]
+    private static partial Regex CreditCardCVVRegex();
+
     public static bool IsCreditCardCVV(this string? creditCardCVV) =>
-        creditCardCVV.IsEmpty() ? false : (_creditCardCVVRegex ??= new Regex(_creditCardCVVPattern, RegexOptions.Compiled)).IsMatch(creditCardCVV!);
+        !creditCardCVV.IsEmpty() && CreditCardCVVRegex().IsMatch(creditCardCVV!);
     #endregion
 
     #region Language recognizing utils - https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#SupportedNamedBlocks
+    [GeneratedRegex(@"\P{IsCyrillic}")]
+    private static partial Regex IsCyrillicRegex();
 
     /// <summary>
     /// True, if there are only Cyrillic symbols.
     /// </summary>
-    public static bool AllCyrillic(string stringToCheck) => !Regex.IsMatch(stringToCheck, @"\P{IsCyrillic}");
+    public static bool AllCyrillic(string stringToCheck) => !IsCyrillicRegex().IsMatch(stringToCheck);
 
     /// <summary>
     /// True, if there is at least one Cyrillic symbol.
     /// </summary>
-    public static bool HasCyrillic(string stringToCheck) => !Regex.IsMatch(stringToCheck, @"\p{IsCyrillic}");
+    public static bool HasCyrillic(string stringToCheck) => !IsCyrillicRegex().IsMatch(stringToCheck);
+
+    [GeneratedRegex(@"\P{IsCyrillicSupplement}")]
+    private static partial Regex IsCyrillicSupplementRegex();
 
     /// <summary>
     /// Cyrillic Supplement is a Unicode block containing Cyrillic letters for writing several minority languages, 
     /// including Abkhaz, Kurdish, Komi, Mordvin, Aleut, Azerbaijani, and Jakovlev's Chuvash orthography.
     /// </summary>
-    public static bool AllCyrillicSupplement(string stringToCheck) => !Regex.IsMatch(stringToCheck, @"\P{IsCyrillicSupplement}");
-    public static bool HasCyrillicSupplement(string stringToCheck) => !Regex.IsMatch(stringToCheck, @"\p{IsCyrillicSupplement}");
+    public static bool AllCyrillicSupplement(string stringToCheck) => !IsCyrillicSupplementRegex().IsMatch(stringToCheck);
+    public static bool HasCyrillicSupplement(string stringToCheck) => !IsCyrillicSupplementRegex().IsMatch(stringToCheck);
+
+    [GeneratedRegex(@"\P{IsBasicLatin}")]
+    private static partial Regex IsBasicLatinRegex();
 
     /// <summary>
     /// True, if there are only Latin symbols.
     /// </summary>
-    public static bool AllBasicLatin(string stringToCheck) => !Regex.IsMatch(stringToCheck, @"\P{IsBasicLatin}");
+    public static bool AllBasicLatin(string stringToCheck) => !IsBasicLatinRegex().IsMatch(stringToCheck);
     
     /// <summary>
     /// True, if there is at least one Latin symbol.
     /// </summary>
-    public static bool HasBasicLatin(string stringToCheck) => !Regex.IsMatch(stringToCheck, @"\p{IsBasicLatin}");
+    public static bool HasBasicLatin(string stringToCheck) => !IsBasicLatinRegex().IsMatch(stringToCheck);
 
     #endregion // Language recognizing utils
 }


### PR DESCRIPTION
By using compile-generated regexes we can improve startup performance (no need to dynamically compile the regex on first invocation) and make library more AOT-friendly